### PR TITLE
Fix Convex processing actions and update UI integrations

### DIFF
--- a/app/components/charts/ChartBuilder.tsx
+++ b/app/components/charts/ChartBuilder.tsx
@@ -15,7 +15,7 @@ import { Line, Bar, Pie, Doughnut } from 'react-chartjs-2';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, Title, Tooltip, Legend, ArcElement);
 
-interface DataColumn {
+export interface DataColumn {
   name: string;
   type: 'string' | 'number' | 'date' | 'boolean';
   values: any[];

--- a/app/components/document/DataUploader.tsx
+++ b/app/components/document/DataUploader.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useAction, useMutation } from 'convex/react';
 import type { Id } from '@convex/_generated/dataModel';
-import { api } from '@convex/_generated/api';
+import { convexApi } from '~/lib/convexClient';
 import * as Papa from 'papaparse';
 import * as XLSX from 'xlsx';
 
@@ -50,8 +50,8 @@ export const DataUploader: React.FC<DataUploaderProps> = ({
     return authState.kind === 'fullyLoggedIn' ? authState.sessionId : undefined;
   }, [authState, sessionId]);
 
-  const generateUploadUrl = useMutation(api.mutations.storage.generateUploadUrl);
-  const processDataFile = useAction(api.actions.dataProcessing.processDataFile);
+  const generateUploadUrl = useMutation(convexApi.mutations.storage.generateUploadUrl);
+  const processDataFile = useAction(convexApi['actions/dataProcessing'].processDataFile);
 
   const detectColumnType = (values: any[]): string => {
     const nonEmptyValues = values.filter((v) => v !== null && v !== undefined && v !== '');

--- a/app/components/document/DocumentUploader.tsx
+++ b/app/components/document/DocumentUploader.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useAction, useMutation } from 'convex/react';
 import type { Id } from '@convex/_generated/dataModel';
-import { api } from '@convex/_generated/api';
+import { convexApi } from '~/lib/convexClient';
 
 import { useChefAuth } from '~/components/chat/ChefAuthWrapper';
 import { formatFileSize } from '~/lib/utils/fileSize';
@@ -39,8 +39,8 @@ export const DocumentUploader: React.FC<DocumentUploaderProps> = ({
     return authState.kind === 'fullyLoggedIn' ? authState.sessionId : undefined;
   }, [authState, sessionId]);
 
-  const generateUploadUrl = useMutation(api.mutations.storage.generateUploadUrl);
-  const processDocument = useAction(api.actions.documentProcessing.processUploadedDocument);
+  const generateUploadUrl = useMutation(convexApi.mutations.storage.generateUploadUrl);
+  const processDocument = useAction(convexApi['actions/documentProcessing'].processUploadedDocument);
 
   const onDrop = useCallback(
     async (acceptedFiles: File[]) => {

--- a/app/components/document/ProcessingStatus.tsx
+++ b/app/components/document/ProcessingStatus.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useQuery } from 'convex/react';
 import type { Id } from '@convex/_generated/dataModel';
-import { api } from '@convex/_generated/api';
+import { convexApi } from '~/lib/convexClient';
 
 interface ProcessingStatusProps {
   documentId?: Id<'uploadedDocuments'>;
@@ -30,11 +30,11 @@ export const ProcessingStatus: React.FC<ProcessingStatusProps> = ({
   className = '',
 }) => {
   const documentStatus = useQuery(
-    documentId ? api.queries.uploadedDocuments.getProcessingStatus : 'skip',
+    convexApi['queries/uploadedDocuments'].getProcessingStatus,
     documentId ? { documentId } : 'skip',
   );
   const dataFileStatus = useQuery(
-    dataFileId ? api.queries.dataFiles.getProcessingStatus : 'skip',
+    convexApi['queries/dataFiles'].getProcessingStatus,
     dataFileId ? { dataFileId } : 'skip',
   );
 

--- a/app/components/template/TemplateSelector.tsx
+++ b/app/components/template/TemplateSelector.tsx
@@ -22,7 +22,8 @@ interface TemplateSuggestion {
 }
 
 interface TemplateSelectorProps {
-  companyId: string;
+  companyId?: string;
+  templates?: Template[];
   suggestedTemplates?: TemplateSuggestion[];
   onTemplateSelect: (templateId: string) => void;
   selectedTemplateId?: string;
@@ -80,6 +81,7 @@ const useMockTemplates = (companyId: string): Template[] => {
 
 export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
   companyId,
+  templates,
   suggestedTemplates = [],
   onTemplateSelect,
   selectedTemplateId,
@@ -89,7 +91,8 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
   const [selectedType, setSelectedType] = useState<string>('all');
   const [searchQuery, setSearchQuery] = useState('');
 
-  const allTemplates = useMockTemplates(companyId);
+  const fallbackTemplates = useMockTemplates(companyId ?? '');
+  const allTemplates = templates ?? fallbackTemplates;
 
   const templateTypes = useMemo(() => {
     const types = ['all', ...new Set(allTemplates.map((t) => t.templateType))];
@@ -115,7 +118,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
         const template = allTemplates.find((t) => t._id === suggestion.templateId);
         return template ? { ...suggestion, template } : null;
       })
-      .filter(Boolean);
+      .filter((suggestion): suggestion is TemplateSuggestion & { template: Template } => suggestion !== null);
   }, [suggestedTemplates, allTemplates]);
 
   const getMatchQualityColor = (score: number): string => {

--- a/app/lib/convexClient.ts
+++ b/app/lib/convexClient.ts
@@ -1,0 +1,82 @@
+import { api } from '@convex/_generated/api';
+import type { FunctionReference } from 'convex/server';
+import type { Id } from '@convex/_generated/dataModel';
+
+type ProcessDataFileArgs = {
+  storageId: Id<'_storage'>;
+  fileName: string;
+  fileType: string;
+  fileSize?: number;
+  companyId?: string;
+  sessionId?: Id<'sessions'>;
+  sampleSize?: number;
+  detectTypes?: boolean;
+  findCorrelations?: boolean;
+};
+
+type ProcessDataFileResult = {
+  success: boolean;
+  dataFileId?: Id<'dataFiles'>;
+  headers?: string[];
+  rowCount?: number;
+  analysis?: unknown;
+  correlations?: unknown;
+  sampleData?: unknown[];
+  error?: string;
+};
+
+type ProcessUploadedDocumentArgs = {
+  storageId: Id<'_storage'>;
+  fileName: string;
+  fileType: string;
+  fileSize?: number;
+  companyId?: string;
+  sessionId?: Id<'sessions'>;
+  extractStructure?: boolean;
+  generateEmbedding?: boolean;
+};
+
+type ProcessUploadedDocumentResult = {
+  success: boolean;
+  documentId?: Id<'uploadedDocuments'>;
+  extractedText?: string;
+  structure?: unknown;
+  metadata?: unknown;
+  error?: string;
+};
+
+type ProcessingStatus = {
+  status: string;
+  progress: number;
+  currentStep: string;
+  error: string | null;
+  startTime: number;
+  endTime: number | null;
+} | null;
+
+type DataProcessingModule = {
+  processDataFile: FunctionReference<'action', 'public', ProcessDataFileArgs, ProcessDataFileResult>;
+};
+
+type DocumentProcessingModule = {
+  processUploadedDocument: FunctionReference<
+    'action',
+    'public',
+    ProcessUploadedDocumentArgs,
+    ProcessUploadedDocumentResult
+  >;
+};
+
+type DataFilesQueryModule = {
+  getProcessingStatus: FunctionReference<'query', 'public', { dataFileId: Id<'dataFiles'> }, ProcessingStatus>;
+};
+
+type UploadedDocumentsQueryModule = {
+  getProcessingStatus: FunctionReference<'query', 'public', { documentId: Id<'uploadedDocuments'> }, ProcessingStatus>;
+};
+
+export const convexApi = api as typeof api &
+  Record<'actions/dataProcessing', DataProcessingModule> &
+  Record<'actions/documentProcessing', DocumentProcessingModule> &
+  Record<'queries/dataFiles', DataFilesQueryModule> &
+  Record<'queries/uploadedDocuments', UploadedDocumentsQueryModule>;

--- a/app/routes/reports.tsx
+++ b/app/routes/reports.tsx
@@ -364,8 +364,10 @@ export default function Reports() {
                         },
                         formatting: {
                           theme: 'professional',
-                          headerStyle: 'standard',
-                          footerIncluded: true,
+                          includePageNumbers: true,
+                          includeTOC: false,
+                          includeHeader: true,
+                          includeFooter: true,
                         },
                       }}
                       onExport={(format) => {

--- a/app/routes/templates.tsx
+++ b/app/routes/templates.tsx
@@ -158,7 +158,6 @@ export default function Templates() {
               <ClientOnly>
                 {() => (
                   <TemplateSelector
-                    templates={templates}
                     onTemplateSelect={(template) => {
                       console.log('Template selected:', template);
                       // TODO: Handle template selection

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -1,5 +1,13 @@
 import { v } from "convex/values";
-import { action, internalMutation, mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
+import {
+  action,
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "./_generated/server";
 import { ConvexError } from "convex/values";
 import type { Id } from "./_generated/dataModel";
 import { getChatByIdOrUrlIdEnsuringAccess } from "./messages";
@@ -225,6 +233,23 @@ export const saveCachedProfile = internalMutation({
     await ctx.db.patch(member._id, {
       cachedProfile: profile,
     });
+  },
+});
+
+export const getCurrentMemberForActions = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await getCurrentMember(ctx);
+  },
+});
+
+export const getMemberByConvexId = internalQuery({
+  args: { convexMemberId: v.string() },
+  handler: async (ctx, args) => {
+    return ctx.db
+      .query("convexMembers")
+      .withIndex("byConvexMemberId", (q) => q.eq("convexMemberId", args.convexMemberId))
+      .first();
   },
 });
 


### PR DESCRIPTION
## Summary
- update Convex data/document processing actions to fetch members via an internal query, validate storage URLs, and support Blob buffers
- expose internal queries in sessions for action contexts and add a typed convexApi helper for referencing processing actions and queries
- adjust document/data uploader components, processing status widget, and related routes to use the new helper and align mock data with type expectations
- add optional template props handling and clean up sample formatting data in UI pages

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cd2a478698832fa44c6f8cb2f89577