### PR TITLE
Fix auth context usage and remove placeholder content

### DIFF
--- a/app/components/template/TemplateSelector.tsx
+++ b/app/components/template/TemplateSelector.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo } from 'react';
-import { useQuery } from 'convex/react';
 
 interface Template {
   _id: string;
@@ -30,57 +29,8 @@ interface TemplateSelectorProps {
   className?: string;
 }
 
-// Mock data for development - replace with actual Convex query
-const useMockTemplates = (companyId: string): Template[] => {
-  // This would be: const templates = useQuery(api.templates.getCompanyTemplates, { companyId });
-  return [
-    {
-      _id: 'template_1',
-      templateName: 'Quarterly Business Report',
-      templateType: 'report',
-      description: 'Comprehensive quarterly business performance report with financial metrics and analysis',
-      usageCount: 23,
-      tags: ['financial', 'quarterly', 'performance'],
-      industry: 'financial',
-      createdAt: Date.now() - 86400000,
-      approvalStatus: 'approved',
-    },
-    {
-      _id: 'template_2',
-      templateName: 'Project Proposal',
-      templateType: 'proposal',
-      description: 'Standard project proposal template with budget, timeline, and deliverables',
-      usageCount: 45,
-      tags: ['project', 'proposal', 'budget'],
-      createdAt: Date.now() - 172800000,
-      approvalStatus: 'approved',
-    },
-    {
-      _id: 'template_3',
-      templateName: 'Executive Summary',
-      templateType: 'memo',
-      description: 'Executive summary template for board presentations and stakeholder updates',
-      usageCount: 12,
-      tags: ['executive', 'summary', 'board'],
-      createdAt: Date.now() - 259200000,
-      approvalStatus: 'approved',
-    },
-    {
-      _id: 'template_4',
-      templateName: 'Marketing Campaign Report',
-      templateType: 'report',
-      description: 'Campaign performance analysis with metrics and ROI calculations',
-      usageCount: 8,
-      tags: ['marketing', 'campaign', 'analytics'],
-      industry: 'marketing',
-      createdAt: Date.now() - 345600000,
-      approvalStatus: 'approved',
-    },
-  ];
-};
-
 export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
-  companyId,
+  companyId: _companyId,
   templates,
   suggestedTemplates = [],
   onTemplateSelect,
@@ -91,8 +41,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
   const [selectedType, setSelectedType] = useState<string>('all');
   const [searchQuery, setSearchQuery] = useState('');
 
-  const fallbackTemplates = useMockTemplates(companyId ?? '');
-  const allTemplates = templates ?? fallbackTemplates;
+  const allTemplates = useMemo(() => templates ?? [], [templates]);
 
   const templateTypes = useMemo(() => {
     const types = ['all', ...new Set(allTemplates.map((t) => t.templateType))];
@@ -288,7 +237,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                   <div>
                     <h3 className="font-medium text-blue-900">AI-Powered Template Matching</h3>
                     <p className="mt-1 text-sm text-blue-700">
-                      Based on your document content, we've found {suggestedTemplatesWithData.length} templates that
+                      Based on your document content, we&apos;ve found {suggestedTemplatesWithData.length} templates that
                       closely match your needs.
                     </p>
                   </div>

--- a/app/routes/documents.tsx
+++ b/app/routes/documents.tsx
@@ -7,6 +7,7 @@ import { Header } from '~/components/header/Header';
 import { DocumentUploader } from '~/components/document/DocumentUploader';
 import { ProcessingStatus } from '~/components/document/ProcessingStatus';
 import type { Id } from '@convex/_generated/dataModel';
+import { ChefAuthProvider } from '~/components/chat/ChefAuthWrapper';
 
 export const meta: MetaFunction = () => {
   return [
@@ -15,7 +16,7 @@ export const meta: MetaFunction = () => {
   ];
 };
 
-export const loader = async (args: LoaderFunctionArgs) => {
+export const loader = async (_args: LoaderFunctionArgs) => {
   // TODO: Fetch user's documents from Convex
   // For now, return empty data
   return json({
@@ -25,6 +26,14 @@ export const loader = async (args: LoaderFunctionArgs) => {
 };
 
 export default function Documents() {
+  return (
+    <ChefAuthProvider redirectIfUnauthenticated={true}>
+      <DocumentsContent />
+    </ChefAuthProvider>
+  );
+}
+
+function DocumentsContent() {
   const { documents, processingQueue } = useLoaderData<typeof loader>();
   const [lastDocumentId, setLastDocumentId] = useState<Id<'uploadedDocuments'> | null>(null);
 

--- a/app/routes/reports.tsx
+++ b/app/routes/reports.tsx
@@ -1,10 +1,34 @@
 import { json } from '@vercel/remix';
 import type { LoaderFunctionArgs, MetaFunction } from '@vercel/remix';
 import { useLoaderData } from '@remix-run/react';
-import { ClientOnly } from 'remix-utils/client-only';
 import { Header } from '~/components/header/Header';
-import { ReportViewer } from '~/components/reports/ReportViewer';
 import { exportData as exportUtility, type ExportFormat } from '~/utils/exportUtils';
+
+type ReportSummary = {
+  id: string;
+  title: string;
+  description?: string;
+  summary?: string;
+  createdAt: number;
+  updatedAt: number;
+  status?: string;
+  type?: string;
+  author?: string;
+  wordCount?: number;
+  pageCount?: number;
+  tags?: string[];
+  sections?: string[];
+  charts?: Array<{ id: string; title: string; type: string }>;
+};
+
+type ReportsLoaderData = {
+  reports: ReportSummary[];
+  filters: {
+    status: string[];
+    type: string[];
+    tags: string[];
+  };
+};
 
 export const meta: MetaFunction = () => {
   return [
@@ -14,80 +38,25 @@ export const meta: MetaFunction = () => {
 };
 
 export const loader = async (_args: LoaderFunctionArgs) => {
-  // TODO: Fetch reports from Convex
-  // For now, return mock data
-  return json({
-    reports: [
-      {
-        id: '1',
-        title: 'Q3 Financial Analysis Report',
-        description: 'Comprehensive analysis of Q3 financial performance with key metrics and trends',
-        createdAt: Date.now() - 86400000, // 1 day ago
-        updatedAt: Date.now() - 3600000, // 1 hour ago
-        status: 'completed',
-        type: 'financial',
-        author: 'AI Assistant',
-        wordCount: 2450,
-        pageCount: 8,
-        tags: ['finance', 'quarterly', 'analysis'],
-        summary: 'Strong Q3 performance with 15% revenue growth and improved operational efficiency.',
-        sections: ['Executive Summary', 'Revenue Analysis', 'Cost Analysis', 'Recommendations'],
-        charts: [
-          { id: 'chart1', title: 'Revenue Trend', type: 'line' },
-          { id: 'chart2', title: 'Expense Breakdown', type: 'pie' },
-        ],
-      },
-      {
-        id: '2',
-        title: 'Market Research Summary',
-        description: 'Analysis of competitor landscape and market opportunities',
-        createdAt: Date.now() - 172800000, // 2 days ago
-        updatedAt: Date.now() - 86400000, // 1 day ago
-        status: 'completed',
-        type: 'research',
-        author: 'AI Assistant',
-        wordCount: 1850,
-        pageCount: 6,
-        tags: ['market', 'research', 'competitive'],
-        summary: 'Identified key growth opportunities in emerging markets with competitive advantages.',
-        sections: ['Market Overview', 'Competitive Analysis', 'Opportunities', 'Strategic Recommendations'],
-        charts: [
-          { id: 'chart3', title: 'Market Share', type: 'bar' },
-          { id: 'chart4', title: 'Growth Projections', type: 'line' },
-        ],
-      },
-      {
-        id: '3',
-        title: 'Project Status Dashboard',
-        description: 'Weekly project status update with milestones and deliverables',
-        createdAt: Date.now() - 259200000, // 3 days ago
-        updatedAt: Date.now() - 172800000, // 2 days ago
-        status: 'draft',
-        type: 'project',
-        author: 'AI Assistant',
-        wordCount: 980,
-        pageCount: 3,
-        tags: ['project', 'status', 'weekly'],
-        summary: 'Project on track with 85% completion rate and all major milestones met.',
-        sections: ['Project Overview', 'Progress Update', 'Issues & Risks', 'Next Steps'],
-        charts: [{ id: 'chart5', title: 'Progress Timeline', type: 'bar' }],
-      },
-    ],
+  const data: ReportsLoaderData = {
+    reports: [],
     filters: {
-      status: ['completed', 'draft', 'in_progress'],
-      type: ['financial', 'research', 'project', 'operational', 'marketing'],
-      tags: ['finance', 'quarterly', 'analysis', 'market', 'research', 'competitive', 'project', 'status', 'weekly'],
+      status: [],
+      type: [],
+      tags: [],
     },
-  });
+  };
+  return json(data);
 };
 
 export default function Reports() {
   const { reports, filters } = useLoaderData<typeof loader>();
 
-  const handleExport = (format: ExportFormat, report: any) => {
+  const handleExport = (format: ExportFormat, report: ReportSummary) => {
+    const exportBody = [report.description, report.summary].filter(Boolean).join('\n\n');
     const exportData = {
       title: report.title,
-      content: report.description + '\n\n' + report.summary,
+      content: exportBody,
       charts: report.charts || [],
       metadata: {
         author: report.author,
@@ -120,48 +89,59 @@ export default function Reports() {
                 {/* Status Filter */}
                 <div className="mb-6">
                   <h4 className="text-content-primary mb-2 text-sm font-medium">Status</h4>
-                  <div className="space-y-2">
-                    {filters.status.map((status) => (
-                      <label key={status} className="flex items-center">
-                        <input
-                          type="checkbox"
-                          className="border-border-primary text-accent-primary rounded"
-                        />
-                        <span className="text-content-secondary ml-2 text-sm capitalize">
-                          {status.replace('_', ' ')}
-                        </span>
-                      </label>
-                    ))}
-                  </div>
+                  {filters.status.length > 0 ? (
+                    <div className="space-y-2">
+                      {filters.status.map((status) => (
+                        <label key={status} className="flex items-center">
+                          <input type="checkbox" className="border-border-primary text-accent-primary rounded" />
+                          <span className="text-content-secondary ml-2 text-sm capitalize">
+                            {status.replace('_', ' ')}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-content-tertiary text-sm">No status filters available.</p>
+                  )}
                 </div>
 
                 {/* Type Filter */}
                 <div className="mb-6">
                   <h4 className="text-content-primary mb-2 text-sm font-medium">Report Type</h4>
-                  <div className="space-y-2">
-                    {filters.type.map((type) => (
-                      <label key={type} className="flex items-center">
-                        <input
-                          type="checkbox"
-                          className="border-border-primary text-accent-primary rounded"
-                        />
-                        <span className="text-content-secondary ml-2 text-sm capitalize">{type}</span>
-                      </label>
-                    ))}
-                  </div>
+                  {filters.type.length > 0 ? (
+                    <div className="space-y-2">
+                      {filters.type.map((type) => (
+                        <label key={type} className="flex items-center">
+                          <input type="checkbox" className="border-border-primary text-accent-primary rounded" />
+                          <span className="text-content-secondary ml-2 text-sm capitalize">{type}</span>
+                        </label>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-content-tertiary text-sm">No type filters available.</p>
+                  )}
                 </div>
 
                 {/* Quick Actions */}
                 <div className="border-border-primary mt-8 border-t pt-6">
                   <h4 className="text-content-primary mb-3 text-sm font-medium">Quick Actions</h4>
                   <div className="space-y-2">
-                    <button type="button" className="text-content-secondary w-full rounded px-3 py-2 text-left text-sm hover:bg-background-primary">
+                    <button
+                      type="button"
+                      className="text-content-secondary w-full rounded px-3 py-2 text-left text-sm hover:bg-background-primary"
+                    >
                       Export All Reports
                     </button>
-                    <button type="button" className="text-content-secondary w-full rounded px-3 py-2 text-left text-sm hover:bg-background-primary">
+                    <button
+                      type="button"
+                      className="text-content-secondary w-full rounded px-3 py-2 text-left text-sm hover:bg-background-primary"
+                    >
                       Generate New Report
                     </button>
-                    <button type="button" className="text-content-secondary w-full rounded px-3 py-2 text-left text-sm hover:bg-background-primary">
+                    <button
+                      type="button"
+                      className="text-content-secondary w-full rounded px-3 py-2 text-left text-sm hover:bg-background-primary"
+                    >
                       Report Templates
                     </button>
                   </div>
@@ -211,173 +191,167 @@ export default function Reports() {
                     <option>Sort by Status</option>
                   </select>
                 </div>
-                <button type="button" className="rounded-lg bg-button-primary-background px-4 py-2 font-medium text-button-primary-text hover:bg-button-primary-background-hover">
+                <button
+                  type="button"
+                  className="rounded-lg bg-button-primary-background px-4 py-2 font-medium text-button-primary-text hover:bg-button-primary-background-hover"
+                >
                   Generate Report
                 </button>
               </div>
 
-              <div className="space-y-6">
-                {reports.map((report) => (
-                  <div
-                    key={report.id}
-                    className="border-border-primary rounded-lg border bg-background-secondary p-6"
+              {reports.length === 0 ? (
+                <div className="border-border-primary flex flex-col items-center justify-center rounded-lg border bg-background-secondary p-10 text-center">
+                  <div className="mb-4 text-5xl">📄</div>
+                  <h2 className="text-content-primary mb-2 text-xl font-semibold">No reports yet</h2>
+                  <p className="text-content-secondary mb-6 max-w-lg text-sm">
+                    Generate a report to see it listed here. Once you create reports, they will appear with quick access
+                    to summaries, sections, and exports.
+                  </p>
+                  <button
+                    type="button"
+                    className="rounded-lg bg-button-primary-background px-4 py-2 font-medium text-button-primary-text hover:bg-button-primary-background-hover"
                   >
-                    <div className="mb-4 flex items-start justify-between">
-                      <div className="flex-1">
-                        <div className="mb-2 flex items-center space-x-3">
-                          <h3 className="text-content-primary text-xl font-semibold">{report.title}</h3>
-                          <span
-                            className={`rounded-full px-2 py-1 text-xs ${
-                              report.status === 'completed'
-                                ? 'bg-green-100 text-green-800'
-                                : report.status === 'draft'
-                                  ? 'bg-yellow-100 text-yellow-800'
-                                  : 'bg-blue-100 text-blue-800'
-                            }`}
-                          >
-                            {report.status}
-                          </span>
-                          <span className="text-content-secondary rounded-full bg-background-primary px-2 py-1 text-xs capitalize">
-                            {report.type}
-                          </span>
+                    Generate Report
+                  </button>
+                </div>
+              ) : (
+                <div className="space-y-6">
+                  {reports.map((report) => {
+                    const status = report.status ?? 'draft';
+                    const statusClass =
+                      status === 'completed'
+                        ? 'bg-green-100 text-green-800'
+                        : status === 'processing'
+                          ? 'bg-yellow-100 text-yellow-800'
+                          : 'bg-blue-100 text-blue-800';
+                    const sections = report.sections ?? [];
+                    const tags = report.tags ?? [];
+                    const charts = report.charts ?? [];
+                    const description = report.description ?? 'No description available yet.';
+                    const summary = report.summary;
+                    return (
+                      <div
+                        key={report.id}
+                        className="border-border-primary rounded-lg border bg-background-secondary p-6"
+                      >
+                        <div className="mb-4 flex items-start justify-between">
+                          <div className="flex-1">
+                            <div className="mb-2 flex items-center space-x-3">
+                              <h3 className="text-content-primary text-xl font-semibold">{report.title}</h3>
+                              <span className={`rounded-full px-2 py-1 text-xs ${statusClass}`}>{status}</span>
+                              {report.type && (
+                                <span className="text-content-secondary rounded-full bg-background-primary px-2 py-1 text-xs capitalize">
+                                  {report.type}
+                                </span>
+                              )}
+                            </div>
+                            <p className="text-content-secondary mb-3">{description}</p>
+                            {summary && (
+                              <p className="text-content-secondary mb-4 text-sm italic">&ldquo;{summary}&rdquo;</p>
+                            )}
+                          </div>
                         </div>
-                        <p className="text-content-secondary mb-3">{report.description}</p>
-                        <p className="text-content-secondary mb-4 text-sm italic">&ldquo;{report.summary}&rdquo;</p>
-                      </div>
-                    </div>
 
-                    <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-3">
-                      <div className="text-sm">
-                        <span className="text-content-secondary">Created:</span>
-                        <span className="text-content-primary ml-1">
-                          {new Date(report.createdAt).toLocaleDateString()}
-                        </span>
-                      </div>
-                      <div className="text-sm">
-                        <span className="text-content-secondary">Pages:</span>
-                        <span className="text-content-primary ml-1">{report.pageCount}</span>
-                      </div>
-                      <div className="text-sm">
-                        <span className="text-content-secondary">Words:</span>
-                        <span className="text-content-primary ml-1">{report.wordCount.toLocaleString()}</span>
-                      </div>
-                    </div>
-
-                    <div className="mb-4">
-                      <div className="mb-2 flex flex-wrap gap-1">
-                        {report.tags.map((tag) => (
-                          <span
-                            key={tag}
-                            className="text-content-secondary rounded bg-background-primary px-2 py-1 text-xs"
-                          >
-                            {tag}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-
-                    <div className="mb-4">
-                      <h4 className="text-content-primary mb-2 text-sm font-medium">Sections:</h4>
-                      <div className="flex flex-wrap gap-2">
-                        {report.sections.map((section, index) => (
-                          <span
-                            key={index}
-                            className="text-content-secondary rounded border bg-background-primary px-2 py-1 text-xs"
-                          >
-                            {section}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-
-                    {report.charts && report.charts.length > 0 && (
-                      <div className="mb-4">
-                        <h4 className="text-content-primary mb-2 text-sm font-medium">Visualizations:</h4>
-                        <div className="flex flex-wrap gap-2">
-                          {report.charts.map((chart) => (
-                            <span
-                              key={chart.id}
-                              className="bg-accent-primary/10 text-accent-primary border-accent-primary/20 rounded border px-2 py-1 text-xs"
-                            >
-                              📊 {chart.title} ({chart.type})
+                        <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-3">
+                          <div className="text-sm">
+                            <span className="text-content-secondary">Created:</span>
+                            <span className="text-content-primary ml-1">
+                              {new Date(report.createdAt).toLocaleDateString()}
                             </span>
-                          ))}
+                          </div>
+                          <div className="text-sm">
+                            <span className="text-content-secondary">Pages:</span>
+                            <span className="text-content-primary ml-1">{report.pageCount ?? '—'}</span>
+                          </div>
+                          <div className="text-sm">
+                            <span className="text-content-secondary">Words:</span>
+                            <span className="text-content-primary ml-1">
+                              {typeof report.wordCount === 'number' ? report.wordCount.toLocaleString() : '—'}
+                            </span>
+                          </div>
+                        </div>
+
+                        <div className="mb-4">
+                          <div className="mb-2 flex flex-wrap gap-1">
+                            {tags.map((tag) => (
+                              <span
+                                key={tag}
+                                className="text-content-secondary rounded bg-background-primary px-2 py-1 text-xs"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+
+                        <div className="mb-4">
+                          <h4 className="text-content-primary mb-2 text-sm font-medium">Sections:</h4>
+                          <div className="flex flex-wrap gap-2">
+                            {sections.map((section, index) => (
+                              <span
+                                key={index}
+                                className="text-content-secondary rounded border bg-background-primary px-2 py-1 text-xs"
+                              >
+                                {section}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+
+                        {charts.length > 0 && (
+                          <div className="mb-4">
+                            <h4 className="text-content-primary mb-2 text-sm font-medium">Visualizations:</h4>
+                            <div className="flex flex-wrap gap-2">
+                              {charts.map((chart) => (
+                                <span
+                                  key={chart.id}
+                                  className="bg-accent-primary/10 text-accent-primary border-accent-primary/20 rounded border px-2 py-1 text-xs"
+                                >
+                                  📊 {chart.title} ({chart.type})
+                                </span>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        <div className="flex items-center justify-between">
+                          <div className="text-content-secondary text-xs">
+                            Last updated {new Date(report.updatedAt).toLocaleDateString()}
+                          </div>
+                          <div className="flex space-x-2">
+                            <button
+                              type="button"
+                              className="border-border-primary text-content-primary rounded border px-3 py-1 text-sm transition-colors hover:bg-background-primary"
+                            >
+                              Preview
+                            </button>
+                            <select
+                              aria-label="Export format"
+                              onChange={(e) => e.target.value && handleExport(e.target.value as ExportFormat, report)}
+                              className="border-border-primary text-content-primary rounded border px-3 py-1 text-sm transition-colors hover:bg-background-primary"
+                              defaultValue=""
+                            >
+                              <option value="" disabled>
+                                Export
+                              </option>
+                              <option value="html">HTML</option>
+                              <option value="pdf">PDF</option>
+                              <option value="docx">Word</option>
+                              <option value="pptx">PowerPoint</option>
+                            </select>
+                            <button
+                              type="button"
+                              className="rounded bg-button-primary-background px-3 py-1 text-sm text-button-primary-text hover:bg-button-primary-background-hover"
+                            >
+                              View Report
+                            </button>
+                          </div>
                         </div>
                       </div>
-                    )}
-
-                    <div className="flex items-center justify-between">
-                      <div className="text-content-secondary text-xs">
-                        Last updated {new Date(report.updatedAt).toLocaleDateString()}
-                      </div>
-                      <div className="flex space-x-2">
-                        <button type="button" className="border-border-primary text-content-primary rounded border px-3 py-1 text-sm transition-colors hover:bg-background-primary">
-                          Preview
-                        </button>
-                        <select
-                          aria-label="Export format"
-                          onChange={(e) => e.target.value && handleExport(e.target.value as ExportFormat, report)}
-                          className="border-border-primary text-content-primary rounded border px-3 py-1 text-sm transition-colors hover:bg-background-primary"
-                          defaultValue=""
-                        >
-                          <option value="" disabled>
-                            Export
-                          </option>
-                          <option value="html">HTML</option>
-                          <option value="pdf">PDF</option>
-                          <option value="docx">Word</option>
-                          <option value="pptx">PowerPoint</option>
-                        </select>
-                        <button type="button" className="rounded bg-button-primary-background px-3 py-1 text-sm text-button-primary-text hover:bg-button-primary-background-hover">
-                          View Report
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              {/* Report Viewer Component (hidden by default, shown when viewing a report) */}
-              <div className="hidden">
-                <ClientOnly>
-                  {() => (
-                    <ReportViewer
-                      report={{
-                        _id: 'sample-1',
-                        reportName: 'Sample Report',
-                        reportType: 'sample',
-                        content: {
-                          body: 'This is a sample report content...',
-                          sections: [],
-                        },
-                        charts: [],
-                        tables: [],
-                        metadata: {
-                          author: 'AI Assistant',
-                          createdDate: Date.now(),
-                          lastModified: Date.now(),
-                          version: '1.0',
-                          confidentiality: 'Internal',
-                          department: 'SousChef',
-                          project: 'Sample',
-                          tags: ['sample'],
-                        },
-                        formatting: {
-                          theme: 'professional',
-                          includePageNumbers: true,
-                          includeTOC: false,
-                          includeHeader: true,
-                          includeFooter: true,
-                        },
-                      }}
-                      onExport={(format) => {
-                        console.log('Export to:', format);
-                        // TODO: Handle export
-                      }}
-                    />
-                  )}
-                </ClientOnly>
-              </div>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/app/routes/templates.tsx
+++ b/app/routes/templates.tsx
@@ -5,6 +5,29 @@ import { ClientOnly } from 'remix-utils/client-only';
 import { Header } from '~/components/header/Header';
 import { TemplateSelector } from '~/components/template/TemplateSelector';
 
+type TemplateDefinition = {
+  id: string;
+  templateName: string;
+  documentType: string;
+  category: string;
+  description: string;
+  lastUpdated: number;
+  usageCount: number;
+  structure: {
+    sections: string[];
+    estimatedLength: string;
+  };
+};
+
+type TemplatesLoaderData = {
+  templates: TemplateDefinition[];
+  categories: string[];
+  searchFilters: {
+    type: string[];
+    industry: string[];
+  };
+};
+
 export const meta: MetaFunction = () => {
   return [
     { title: 'Templates | SousChef' },
@@ -12,57 +35,16 @@ export const meta: MetaFunction = () => {
   ];
 };
 
-export const loader = async (args: LoaderFunctionArgs) => {
-  // TODO: Fetch templates from Convex
-  // For now, return mock data
-  return json({
-    templates: [
-      {
-        id: '1',
-        templateName: 'Executive Report Template',
-        documentType: 'report',
-        category: 'Business',
-        description: 'Professional executive report format with executive summary, findings, and recommendations',
-        lastUpdated: Date.now() - 86400000, // 1 day ago
-        usageCount: 45,
-        structure: {
-          sections: ['Executive Summary', 'Key Findings', 'Recommendations', 'Next Steps'],
-          estimatedLength: '3-5 pages',
-        },
-      },
-      {
-        id: '2',
-        templateName: 'Financial Analysis Report',
-        documentType: 'financial',
-        category: 'Finance',
-        description: 'Comprehensive financial analysis template with charts, ratios, and variance analysis',
-        lastUpdated: Date.now() - 172800000, // 2 days ago
-        usageCount: 32,
-        structure: {
-          sections: ['Financial Summary', 'Performance Analysis', 'Variance Explanation', 'Outlook'],
-          estimatedLength: '4-6 pages',
-        },
-      },
-      {
-        id: '3',
-        templateName: 'Project Status Report',
-        documentType: 'project',
-        category: 'Operations',
-        description: 'Project management report template with milestones, risks, and timeline tracking',
-        lastUpdated: Date.now() - 259200000, // 3 days ago
-        usageCount: 28,
-        structure: {
-          sections: ['Project Overview', 'Status Update', 'Issues & Risks', 'Next Milestones'],
-          estimatedLength: '2-3 pages',
-        },
-      },
-    ],
-    categories: ['Business', 'Finance', 'Operations', 'Technical', 'Marketing', 'Legal'],
+export const loader = async (_args: LoaderFunctionArgs) => {
+  const data: TemplatesLoaderData = {
+    templates: [],
+    categories: [],
     searchFilters: {
-      type: ['report', 'proposal', 'memo', 'analysis', 'project', 'financial'],
-      industry: ['technology', 'finance', 'healthcare', 'manufacturing', 'retail'],
+      type: [],
+      industry: [],
     },
-  });
+  };
+  return json(data);
 };
 
 export default function Templates() {
@@ -89,33 +71,41 @@ export default function Templates() {
                 {/* Category Filter */}
                 <div className="mb-6">
                   <h4 className="text-bolt-elements-textPrimary mb-2 text-sm font-medium">Category</h4>
-                  <div className="space-y-2">
-                    {categories.map((category) => (
-                      <label key={category} className="flex items-center">
-                        <input
-                          type="checkbox"
-                          className="border-bolt-elements-borderColor text-bolt-elements-focus rounded"
-                        />
-                        <span className="text-bolt-elements-textSecondary ml-2 text-sm">{category}</span>
-                      </label>
-                    ))}
-                  </div>
+                  {categories.length > 0 ? (
+                    <div className="space-y-2">
+                      {categories.map((category) => (
+                        <label key={category} className="flex items-center">
+                          <input
+                            type="checkbox"
+                            className="border-bolt-elements-borderColor text-bolt-elements-focus rounded"
+                          />
+                          <span className="text-bolt-elements-textSecondary ml-2 text-sm">{category}</span>
+                        </label>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-bolt-elements-textSecondary text-sm">No categories available yet.</p>
+                  )}
                 </div>
 
                 {/* Document Type Filter */}
                 <div className="mb-6">
                   <h4 className="text-bolt-elements-textPrimary mb-2 text-sm font-medium">Document Type</h4>
-                  <div className="space-y-2">
-                    {searchFilters.type.map((type) => (
-                      <label key={type} className="flex items-center">
-                        <input
-                          type="checkbox"
-                          className="border-bolt-elements-borderColor text-bolt-elements-focus rounded"
-                        />
-                        <span className="text-bolt-elements-textSecondary ml-2 text-sm capitalize">{type}</span>
-                      </label>
-                    ))}
-                  </div>
+                  {searchFilters.type.length > 0 ? (
+                    <div className="space-y-2">
+                      {searchFilters.type.map((type) => (
+                        <label key={type} className="flex items-center">
+                          <input
+                            type="checkbox"
+                            className="border-bolt-elements-borderColor text-bolt-elements-focus rounded"
+                          />
+                          <span className="text-bolt-elements-textSecondary ml-2 text-sm capitalize">{type}</span>
+                        </label>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-bolt-elements-textSecondary text-sm">No document types available yet.</p>
+                  )}
                 </div>
 
                 {/* Usage Stats */}
@@ -158,9 +148,19 @@ export default function Templates() {
               <ClientOnly>
                 {() => (
                   <TemplateSelector
-                    onTemplateSelect={(template) => {
-                      console.log('Template selected:', template);
-                      // TODO: Handle template selection
+                    templates={templates.map((template) => ({
+                      _id: template.id,
+                      templateName: template.templateName,
+                      templateType: template.documentType,
+                      description: template.description,
+                      usageCount: template.usageCount,
+                      tags: template.structure.sections,
+                      industry: undefined,
+                      createdAt: template.lastUpdated,
+                      approvalStatus: 'unknown',
+                    }))}
+                    onTemplateSelect={() => {
+                      /* Intentionally empty until template actions are implemented. */
                     }}
                     className="grid grid-cols-1 gap-6 md:grid-cols-2"
                   />
@@ -169,69 +169,84 @@ export default function Templates() {
 
               {/* Template Cards */}
               <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-2">
-                {templates.map((template) => (
-                  <div
-                    key={template.id}
-                    className="border-bolt-elements-borderColor hover:border-bolt-elements-focus rounded-lg border bg-bolt-elements-background-depth-2 p-6 transition-colors"
-                  >
-                    <div className="mb-4 flex items-start justify-between">
-                      <h3 className="text-bolt-elements-textPrimary text-lg font-semibold">{template.templateName}</h3>
-                      <span className="text-bolt-elements-textSecondary rounded-full bg-bolt-elements-background-depth-3 px-2 py-1 text-xs">
-                        {template.category}
-                      </span>
-                    </div>
-
-                    <p className="text-bolt-elements-textSecondary mb-4 text-sm">{template.description}</p>
-
-                    <div className="mb-4 space-y-2">
-                      <div className="flex justify-between text-sm">
-                        <span className="text-bolt-elements-textSecondary">Document Type:</span>
-                        <span className="text-bolt-elements-textPrimary capitalize">{template.documentType}</span>
-                      </div>
-                      <div className="flex justify-between text-sm">
-                        <span className="text-bolt-elements-textSecondary">Usage Count:</span>
-                        <span className="text-bolt-elements-textPrimary">{template.usageCount}</span>
-                      </div>
-                      <div className="flex justify-between text-sm">
-                        <span className="text-bolt-elements-textSecondary">Estimated Length:</span>
-                        <span className="text-bolt-elements-textPrimary">{template.structure.estimatedLength}</span>
-                      </div>
-                    </div>
-
-                    <div className="mb-4">
-                      <h4 className="text-bolt-elements-textPrimary mb-2 text-sm font-medium">Sections:</h4>
-                      <div className="flex flex-wrap gap-1">
-                        {template.structure.sections.slice(0, 3).map((section, index) => (
-                          <span
-                            key={index}
-                            className="text-bolt-elements-textSecondary rounded bg-bolt-elements-background-depth-1 px-2 py-1 text-xs"
-                          >
-                            {section}
-                          </span>
-                        ))}
-                        {template.structure.sections.length > 3 && (
-                          <span className="text-bolt-elements-textSecondary rounded bg-bolt-elements-background-depth-1 px-2 py-1 text-xs">
-                            +{template.structure.sections.length - 3} more
-                          </span>
-                        )}
-                      </div>
-                    </div>
-
-                    <div className="flex items-center justify-between">
-                      <span className="text-bolt-elements-textSecondary text-xs">
-                        Updated {new Date(template.lastUpdated).toLocaleDateString()}
-                      </span>
-                      <div className="flex space-x-2">
-                        <button className="border-bolt-elements-borderColor text-bolt-elements-textPrimary rounded border px-3 py-1 text-sm transition-colors hover:bg-bolt-elements-background-depth-3">
-                          Preview
-                        </button>
-                        <button className="rounded bg-bolt-elements-button-primary-background px-3 py-1 text-sm text-bolt-elements-button-primary-text hover:bg-bolt-elements-button-primary-backgroundHover">
-                          Use Template
-                        </button>
-                      </div>
-                    </div>
+                {templates.length === 0 ? (
+                  <div className="border-bolt-elements-borderColor col-span-full flex flex-col items-center justify-center rounded-lg border bg-bolt-elements-background-depth-2 p-10 text-center">
+                    <div className="mb-4 text-5xl">🗂️</div>
+                    <h2 className="text-bolt-elements-textPrimary mb-2 text-xl font-semibold">No templates uploaded</h2>
+                    <p className="text-bolt-elements-textSecondary mb-6 max-w-lg text-sm">
+                      Upload a template or create one from scratch to start building standardized documents.
+                    </p>
+                    <button className="rounded-lg bg-bolt-elements-button-primary-background px-4 py-2 font-medium text-bolt-elements-button-primary-text hover:bg-bolt-elements-button-primary-backgroundHover">
+                      Upload Template
+                    </button>
                   </div>
-                ))}
+                ) : (
+                  templates.map((template) => (
+                    <div
+                      key={template.id}
+                      className="border-bolt-elements-borderColor hover:border-bolt-elements-focus rounded-lg border bg-bolt-elements-background-depth-2 p-6 transition-colors"
+                    >
+                      <div className="mb-4 flex items-start justify-between">
+                        <h3 className="text-bolt-elements-textPrimary text-lg font-semibold">
+                          {template.templateName}
+                        </h3>
+                        <span className="text-bolt-elements-textSecondary rounded-full bg-bolt-elements-background-depth-3 px-2 py-1 text-xs">
+                          {template.category}
+                        </span>
+                      </div>
+
+                      <p className="text-bolt-elements-textSecondary mb-4 text-sm">{template.description}</p>
+
+                      <div className="mb-4 space-y-2">
+                        <div className="flex justify-between text-sm">
+                          <span className="text-bolt-elements-textSecondary">Document Type:</span>
+                          <span className="text-bolt-elements-textPrimary capitalize">{template.documentType}</span>
+                        </div>
+                        <div className="flex justify-between text-sm">
+                          <span className="text-bolt-elements-textSecondary">Usage Count:</span>
+                          <span className="text-bolt-elements-textPrimary">{template.usageCount}</span>
+                        </div>
+                        <div className="flex justify-between text-sm">
+                          <span className="text-bolt-elements-textSecondary">Estimated Length:</span>
+                          <span className="text-bolt-elements-textPrimary">{template.structure.estimatedLength}</span>
+                        </div>
+                      </div>
+
+                      <div className="mb-4">
+                        <h4 className="text-bolt-elements-textPrimary mb-2 text-sm font-medium">Sections:</h4>
+                        <div className="flex flex-wrap gap-1">
+                          {template.structure.sections.slice(0, 3).map((section, index) => (
+                            <span
+                              key={index}
+                              className="text-bolt-elements-textSecondary rounded bg-bolt-elements-background-depth-1 px-2 py-1 text-xs"
+                            >
+                              {section}
+                            </span>
+                          ))}
+                          {template.structure.sections.length > 3 && (
+                            <span className="text-bolt-elements-textSecondary rounded bg-bolt-elements-background-depth-1 px-2 py-1 text-xs">
+                              +{template.structure.sections.length - 3} more
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <span className="text-bolt-elements-textSecondary text-xs">
+                          Updated {new Date(template.lastUpdated).toLocaleDateString()}
+                        </span>
+                        <div className="flex space-x-2">
+                          <button className="border-bolt-elements-borderColor text-bolt-elements-textPrimary rounded border px-3 py-1 text-sm transition-colors hover:bg-bolt-elements-background-depth-3">
+                            Preview
+                          </button>
+                          <button className="rounded bg-bolt-elements-button-primary-background px-3 py-1 text-sm text-bolt-elements-button-primary-text hover:bg-bolt-elements-button-primary-backgroundHover">
+                            Use Template
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ))
+                )}
               </div>
             </div>
           </div>

--- a/app/routes/visualize.tsx
+++ b/app/routes/visualize.tsx
@@ -7,15 +7,14 @@ import { Header } from '~/components/header/Header';
 import { ChartBuilder } from '~/components/charts/ChartBuilder';
 import type { DataColumn } from '~/components/charts/ChartBuilder';
 import { DataUploader } from '~/components/document/DataUploader';
+import { ChefAuthProvider } from '~/components/chat/ChefAuthWrapper';
 
 const VALID_COLUMN_TYPES = ['string', 'number', 'boolean', 'date'] as const;
 
 const isValidColumnType = (type: string): type is (typeof VALID_COLUMN_TYPES)[number] =>
   (VALID_COLUMN_TYPES as readonly string[]).includes(type);
 
-const toChartColumns = (
-  columns: Array<{ name: string; type: string; values: unknown }>,
-): DataColumn[] =>
+const toChartColumns = (columns: Array<{ name: string; type: string; values: unknown }>): DataColumn[] =>
   columns.map((column) => ({
     name: column.name,
     type: isValidColumnType(column.type) ? column.type : 'string',
@@ -29,7 +28,7 @@ export const meta: MetaFunction = () => {
   ];
 };
 
-export const loader = async (args: LoaderFunctionArgs) => {
+export const loader = async (_args: LoaderFunctionArgs) => {
   // TODO: Fetch user's data files and charts from Convex
   // For now, return mock data
   return json({
@@ -115,15 +114,21 @@ export const loader = async (args: LoaderFunctionArgs) => {
 };
 
 export default function Visualize() {
+  return (
+    <ChefAuthProvider redirectIfUnauthenticated={true}>
+      <VisualizeContent />
+    </ChefAuthProvider>
+  );
+}
+
+function VisualizeContent() {
   const { dataFiles: rawDataFiles, savedCharts, chartRecommendations } = useLoaderData<typeof loader>();
 
   const dataFiles = useMemo(
     () =>
       rawDataFiles.map((file) => ({
         ...file,
-        columns: toChartColumns(
-          file.columns as Array<{ name: string; type: string; values: unknown }>,
-        ),
+        columns: toChartColumns(file.columns as Array<{ name: string; type: string; values: unknown }>),
       })),
     [rawDataFiles],
   );


### PR DESCRIPTION
## Summary
- wrap the documents and visualize routes with the ChefAuth provider so uploader components receive auth context safely
- remove placeholder data from the reports and templates routes, replacing it with typed empty states and user guidance
- drop the template selector's mock data fallback so it only renders provided data and handles empty suggestions cleanly

## Testing
- pnpm lint:app *(fails: repository-wide lint errors for tailwind custom class names and existing unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7cbd8598832fa1980940fe2378a7